### PR TITLE
Restore dev-bridge + GSM public-config (port 3000)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@google-cloud/pubsub": "^4.3.0",
-    "@google-cloud/secret-manager": "^5.0.0",
+    "@google-cloud/secret-manager": "^5.6.0",
     "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-collapsible": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ importers:
         specifier: ^4.3.0
         version: 4.11.0
       '@google-cloud/secret-manager':
-        specifier: ^5.0.0
+        specifier: ^5.6.0
         version: 5.6.0
       '@phosphor-icons/react':
         specifier: ^2.1.10

--- a/src/app/api/public-config/route.ts
+++ b/src/app/api/public-config/route.ts
@@ -1,40 +1,13 @@
 import { NextResponse } from "next/server";
+import { loadPublicConfig } from "~/lib/config.server";
 
-// This endpoint serves only safe public Firebase configuration
-// that can be exposed to the client without security risks
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
 export async function GET() {
-  const config = {
-    apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
-    authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
-    projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
-    storageBucket:
-      process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET ||
-      `${process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID}.firebasestorage.app`,
-    messagingSenderId:
-      process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID || "207501673877",
-    appId:
-      process.env.NEXT_PUBLIC_FIREBASE_APP_ID ||
-      "1:207501673877:web:8c8265c153623cf14ae29c",
-    measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
-  };
-
-  // Validate that required fields are present
-  if (
-    !config.apiKey ||
-    !config.authDomain ||
-    !config.projectId ||
-    !config.appId
-  ) {
-    console.error("[public-config] Missing required Firebase configuration");
-    return NextResponse.json(
-      { error: "Firebase configuration not available" },
-      { status: 500 },
-    );
+  const cfg = await loadPublicConfig();
+  if (!cfg.ok) {
+    return NextResponse.json({ error: "Firebase configuration not available", missing: cfg.missing }, { status: 500 });
   }
-
-  return NextResponse.json(config, {
-    headers: {
-      "Cache-Control": "public, max-age=300", // Cache for 5 minutes
-    },
-  });
+  return NextResponse.json({ firebase: cfg.firebase, app: cfg.app, features: cfg.features }, { headers: { "cache-control": "no-store" } });
 }

--- a/src/config/dev-bridge.ts
+++ b/src/config/dev-bridge.ts
@@ -1,0 +1,18 @@
+export const REMOTE_BASE = "https://siraj.life";
+export const REMOTE_PREFIX = "/api";
+
+export function isLocalhost(host: string | null | undefined): boolean {
+  if (!host) return false;
+  const h = host.toLowerCase();
+  return h.startsWith("localhost") || h.startsWith("127.0.0.1");
+}
+
+export function buildUpstreamUrl(pathname: string, search: string = ""): string {
+  const clean = pathname.replace(/^\/+/, "");
+  const base = new URL(REMOTE_PREFIX.replace(/\/+$/, "/") + clean, REMOTE_BASE);
+  if (search) {
+    const s = search.startsWith("?") ? search : `?${search}`;
+    return new URL(s, base).toString();
+  }
+  return base.toString();
+}

--- a/src/lib/config.server.ts
+++ b/src/lib/config.server.ts
@@ -1,0 +1,79 @@
+/* server-only */
+import "server-only";
+import { SecretManagerServiceClient } from "@google-cloud/secret-manager";
+
+type SecretMap = Record<string, string | undefined>;
+const cache: { loaded?: SecretMap; at?: number } = {};
+
+async function fetchSecret(name: string): Promise<string | undefined> {
+  try {
+    const client = new SecretManagerServiceClient();
+    const [access] = await client.accessSecretVersion({ name: `projects/${process.env.GOOGLE_CLOUD_PROJECT ?? process.env.GCLOUD_PROJECT}/secrets/${name}/versions/latest` });
+    return access?.payload?.data?.toString();
+  } catch {
+    return undefined;
+  }
+}
+
+export async function loadPublicConfig(): Promise<{
+  ok: boolean;
+  firebase?: {
+    apiKey?: string;
+    projectId?: string;
+    authDomain?: string;
+    appId?: string;
+    messagingSenderId?: string;
+    storageBucket?: string;
+  };
+  app?: {
+    websiteUrl?: string;
+    paynowStoreId?: string;
+    backgroundImageUrl?: string;
+    discordInviteUrl?: string;
+    gameserverConnectionMessage?: string;
+  };
+  features?: Record<string, unknown>;
+  missing?: string[];
+}> {
+  if (!cache.loaded || !cache.at || Date.now() - cache.at > 60_000) {
+    const names = [
+      "NEXT_PUBLIC_FIREBASE_API_KEY",
+      "NEXT_PUBLIC_FIREBASE_PROJECT_ID",
+      "NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN",
+      "NEXT_PUBLIC_FIREBASE_APP_ID",
+      "NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID",
+      "NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET",
+      "NEXT_PUBLIC_WEBSITE_URL",
+      "NEXT_PUBLIC_PAYNOW_STORE_ID",
+      "NEXT_PUBLIC_BACKGROUND_IMAGE_URL",
+      "NEXT_PUBLIC_DISCORD_INVITE_URL",
+      "NEXT_PUBLIC_GAMESERVER_CONNECTION_MESSAGE",
+    ];
+    const entries = await Promise.all(names.map(async n => [n, await fetchSecret(n)] as const));
+    cache.loaded = Object.fromEntries(entries);
+    cache.at = Date.now();
+  }
+  const s = cache.loaded!;
+  const miss = Object.entries(s).filter(([,v]) => !v).map(([k]) => k);
+
+  return {
+    ok: miss.length === 0,
+    firebase: {
+      apiKey: s.NEXT_PUBLIC_FIREBASE_API_KEY,
+      projectId: s.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+      authDomain: s.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+      appId: s.NEXT_PUBLIC_FIREBASE_APP_ID,
+      messagingSenderId: s.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+      storageBucket: s.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+    },
+    app: {
+      websiteUrl: s.NEXT_PUBLIC_WEBSITE_URL,
+      paynowStoreId: s.NEXT_PUBLIC_PAYNOW_STORE_ID,
+      backgroundImageUrl: s.NEXT_PUBLIC_BACKGROUND_IMAGE_URL,
+      discordInviteUrl: s.NEXT_PUBLIC_DISCORD_INVITE_URL,
+      gameserverConnectionMessage: s.NEXT_PUBLIC_GAMESERVER_CONNECTION_MESSAGE,
+    },
+    features: {},
+    missing: miss,
+  };
+}


### PR DESCRIPTION
Reintroduces /api/dev-proxy with JSON guard and GSM-backed /api/public-config. No .env usage. Verified locally with smoke scripts on 3000.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added a localhost-only dev proxy for forwarding requests, enforcing JSON responses, and providing clearer error feedback during development.
* Refactor
  * Reworked public config endpoint to load configuration dynamically, return a structured payload, and remove caching for always-fresh values with explicit error messages when unavailable.
* Chores
  * Introduced a server-side config loader backed by Secret Manager with short-lived caching for reliability.
  * Upgraded a dependency to the latest minor version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->